### PR TITLE
fix: next() undefined in sampled path, middleware double-counts events, res.send stacking

### DIFF
--- a/src/core/Telyx.ts
+++ b/src/core/Telyx.ts
@@ -62,10 +62,11 @@ export class Telyx {
       const start = Date.now();
 
       try {
-        // Create a next function that resolves with the actual result
-        let result: T;
-        const next = () => Promise.resolve(result as T);
-        result = await fn(input, next);
+        // Create a next function that resolves with the input (consistent with non-sampled path)
+        // Note: result is not yet available when next() is called synchronously inside fn,
+        // so we pass input through, matching the non-sampled behavior.
+        const next = () => Promise.resolve(input as T);
+        const result = await fn(input, next);
         this.recordSuccess(methodName, Date.now() - start, { input: this.sanitizeInput(input) });
         return result;
       } catch (err) {

--- a/src/middleware/TelyxMiddleware.ts
+++ b/src/middleware/TelyxMiddleware.ts
@@ -11,8 +11,14 @@ export class TelyxMiddleware {
    * Express-like middleware for HTTP requests
    */
   public httpRequestMiddleware = (req: any, res: any, next: any) => {
+    // Prevent double-wrapping if middleware is applied multiple times
+    if ((res as any)._telyxWrapped) {
+      return next();
+    }
+    (res as any)._telyxWrapped = true;
+
     const start = Date.now();
-    
+
     // Track the request
     this.telyx.recordEvent('http_request', {
       method: req.method,
@@ -46,11 +52,6 @@ export class TelyxMiddleware {
    */
   public databaseQueryMiddleware = (query: string, params?: any) => {
     const start = Date.now();
-    
-    this.telyx.recordEvent('database_query_start', {
-      query: this.sanitizeQuery(query),
-      paramsCount: params ? Object.keys(params).length : 0,
-    });
 
     return {
       end: (result: any, error?: any) => {
@@ -76,12 +77,6 @@ export class TelyxMiddleware {
    */
   public cacheOperationMiddleware = (operation: string, key: string, value?: any) => {
     const start = Date.now();
-    
-    this.telyx.recordEvent('cache_operation', {
-      operation,
-      key,
-      hasValue: value !== undefined,
-    });
 
     return {
       end: (result: any, error?: any) => {


### PR DESCRIPTION
## Bugs Fixed

### 1. `trackMethod` sampled path `next()` returns `undefined`
`next()` was defined as `Promise.resolve(result)` where `result` is a `let` variable that hasn't been assigned yet. When the tracked function calls `next()` synchronously, it gets `undefined` instead of the input. The non-sampled path correctly returns `input` — now the sampled path does too.

### 2. Middleware double-counts events
`databaseQueryMiddleware` and `cacheOperationMiddleware` each record a `_start` event immediately, then another event on completion. Every query/operation produces 2 events, doubling counts and skewing all analytics (error rates, throughput, avg response time).

Fix: removed the premature start events. Success/error events are sufficient.

### 3. `httpRequestMiddleware` res.send stacking
The middleware monkey-patches `res.send` without any guard. If applied to the same response object multiple times (nested middleware, shared references), each application adds another wrapper. N applications = N duplicate events per response.

Fix: added `_telyxWrapped` flag to prevent double-wrapping.