### PR TITLE
fix: error rate inflation, res.send chaining, anomaly bucket collision

### DIFF
--- a/src/analytics/TelyxAnalytics.ts
+++ b/src/analytics/TelyxAnalytics.ts
@@ -97,8 +97,10 @@ export class TelyxAnalytics {
     methodPerformance: Record<string, unknown>;
     } {
     const totalEvents = this.events.length;
-    const successfulEvents = this.events.filter(event => event.success).length;
-    const failedEvents = this.events.filter(event => !event.success).length;
+    // Only count events that have an explicit success boolean — custom events
+    // (recordEvent) have no success field and must not inflate failure counts.
+    const successfulEvents = this.events.filter(event => event.success === true).length;
+    const failedEvents = this.events.filter(event => event.success === false).length;
 
     // Calculate average response time from all method calls
     const methodEvents = this.events.filter(event => event.duration !== undefined);
@@ -261,7 +263,8 @@ export class TelyxAnalytics {
     const buckets: Record<string, number> = {};
     spikeEvents.forEach(event => {
       const bucketTime = new Date(event.timestamp);
-      const bucketKey = `${bucketTime.getHours()}:${Math.floor(bucketTime.getMinutes() / 10) * 10}`;
+      // Include date in bucket key so multi-day data doesn't collide
+      const bucketKey = `${bucketTime.toISOString().substring(0, 10)} ${bucketTime.getHours()}:${Math.floor(bucketTime.getMinutes() / 10) * 10}`;
       buckets[bucketKey] = (buckets[bucketKey] || 0) + 1;
     });
     

--- a/src/middleware/TelyxMiddleware.ts
+++ b/src/middleware/TelyxMiddleware.ts
@@ -59,12 +59,12 @@ export class TelyxMiddleware {
             contentLength: typeof body === 'string' ? body.length : 0,
           });
 
-          originalSend.call(res, body);
+          return originalSend.call(res, body);
         } catch (error) {
           // If telemetry fails, don't break the response
           console.error('[Telyx] Failed to track HTTP response:', error);
           try {
-            originalSend.call(res, body);
+            return originalSend.call(res, body);
           } catch (sendError) {
             console.error('[Telyx] Failed to send response after telemetry error:', sendError);
           }

--- a/test/telyx.test.mjs
+++ b/test/telyx.test.mjs
@@ -170,6 +170,20 @@ describe('TelyxAnalytics', () => {
     assert.equal(a.getSystemHealth().totalCalls, 0);
     assert.equal(a.getErrorAnalysis().totalErrors, 0);
   });
+
+  it('getSystemHealth does not count custom events without success as failures', () => {
+    const a = new TelyxAnalytics();
+    // Custom event with no success property — should NOT inflate error rate
+    a.addEvents([
+      makeEvent({ method: 'fetch', duration: 50, success: true }),
+      { timestamp: new Date().toISOString(), agent: 'a', environment: 't', event: 'custom_click', metadata: {} },
+    ]);
+    const health = a.getSystemHealth();
+    // totalCalls counts all events (2), but only 1 has success=true
+    assert.equal(health.totalCalls, 2);
+    assert.equal(health.successRate, 0.5); // 1 out of 2 total
+    assert.equal(health.errorRate, 0); // custom event is NOT a failure
+  });
 });
 
 // ─── TelyxMiddleware ───


### PR DESCRIPTION
Three bugs found in this round:

**1. Error rate inflation in `getSystemHealth()` (most impactful)**
`getSystemHealth()` used falsy checks (`event.success` / `!event.success`) to count successes and failures. Custom events recorded via `recordEvent()` have no `success` property, so `!event.success` was `true` — every custom event counted as a failure. This made the error rate look artificially high anytime you tracked non-method events alongside method calls.

`getSummary()` already used strict equality (`=== true` / `=== false`) and was correct. Now `getSystemHealth()` matches.

**2. `res.send()` wrapper breaks Express chaining**
The HTTP middleware wraps `res.send` to track response timing, but didn't return the result of `originalSend.call(res, body)`. Express's `res.send()` returns the response object for chaining — dropping it breaks patterns like `res.send(data).status(200)` and any middleware that chains on the return value.

**3. Anomaly spike detection cross-day bucket collision**
`detectAnomalies()` grouped events into 10-minute buckets using only `HH:MM` as the key — no date component. For multi-day analytics (7d window), events from Monday 2pm and Thursday 2pm landed in the same bucket, making spike detection meaningless. Now includes the date in the bucket key.

All 33 tests passing (added regression test for error-rate inflation).