### PR TITLE
fix: record failure events with success=false on method errors

### DIFF
--- a/src/Telyx.test.ts
+++ b/src/Telyx.test.ts
@@ -109,6 +109,25 @@ describe('Telyx', () => {
 
       await expect(trackedMethod('test input')).rejects.toThrow('Test error');
     });
+
+    it('should create a failure event with success=false on error', async () => {
+      const trackedMethod = telyx.trackMethod('failing_method', async (_input, _next) => {
+        throw new Error('Boom');
+      });
+
+      await expect(trackedMethod('input')).rejects.toThrow('Boom');
+
+      const batch = getBatch(telyx);
+      // Should have a failure event with success=false
+      const failureEvent = batch.events.find(e => e.success === false);
+      expect(failureEvent).toBeDefined();
+      expect(failureEvent!.method).toBe('failing_method');
+      expect(failureEvent!.success).toBe(false);
+      expect(failureEvent!.duration).toBeGreaterThanOrEqual(0);
+      // Should also have the error in the errors array
+      expect(batch.errors).toHaveLength(1);
+      expect(batch.errors[0].error).toBe('Boom');
+    });
   });
 
   describe('Sampling', () => {

--- a/src/analytics/TelyxAnalytics.ts
+++ b/src/analytics/TelyxAnalytics.ts
@@ -16,9 +16,7 @@ export class TelyxAnalytics {
    * Add events from telemetry batch
    */
   public addEvents(events: TelyxEvent[]): void {
-    for (const event of events) {
-      this.events.push(event);
-    }
+    this.events.push(...events);
     this.cleanupData();
   }
 
@@ -26,9 +24,7 @@ export class TelyxAnalytics {
    * Add metrics from telemetry batch
    */
   public addMetrics(metrics: TelyxMetric[]): void {
-    for (const metric of metrics) {
-      this.metrics.push(metric);
-    }
+    this.metrics.push(...metrics);
     this.cleanupData();
   }
 
@@ -36,9 +32,7 @@ export class TelyxAnalytics {
    * Add errors from telemetry batch
    */
   public addErrors(errors: TelyxError[]): void {
-    for (const error of errors) {
-      this.errors.push(error);
-    }
+    this.errors.push(...errors);
     this.cleanupData();
   }
 

--- a/src/core/Telyx.ts
+++ b/src/core/Telyx.ts
@@ -102,6 +102,11 @@ export class Telyx {
         this.recordSuccess(methodName, Date.now() - start, { input: this.sanitizeInput(input) });
         return result;
       } catch (err) {
+        const duration = Date.now() - start;
+        // Record a failure event so analytics (error rate, failed calls, anomaly
+        // detection) work correctly. recordError() alone only pushes to the
+        // errors array — it does not create a trackable event.
+        this.recordFailure(methodName, duration, { input: this.sanitizeInput(input) });
         this.recordError(methodName, err, { input: this.sanitizeInput(input) });
         throw err;
       }
@@ -209,6 +214,42 @@ export class Telyx {
     
     if (this.config.enableConsole) {
       console.log('[Telyx] Success:', event);
+    }
+  }
+
+  /**
+   * Record a method failure — creates a trackable event with success=false
+   * so that analytics (error rate, failed calls, anomaly detection) work.
+   */
+  public recordFailure(methodName: string, duration: number, metadata?: Record<string, unknown>): void {
+    if (typeof methodName !== 'string' || methodName.trim() === '') {
+      throw new Error('methodName must be a non-empty string');
+    }
+
+    if (typeof duration !== 'number' || duration < 0) {
+      throw new Error('duration must be a non-negative number');
+    }
+
+    if (metadata && typeof metadata !== 'object') {
+      throw new Error('metadata must be an object if provided');
+    }
+
+    const event: TelyxEvent = {
+      timestamp: new Date().toISOString(),
+      agent: this.config.agentName,
+      environment: this.config.environment,
+      event: 'method_failure',
+      method: methodName,
+      duration,
+      success: false,
+      metadata,
+    };
+
+    this.batch.events.push(event);
+    this.checkBatchSize();
+
+    if (this.config.enableConsole) {
+      console.log('[Telyx] Failure:', event);
     }
   }
 


### PR DESCRIPTION
CRITICAL: Fixed trackMethod not creating failure events when tracked methods throw. Before this fix, recordError() only pushed to the errors array but didn't create a trackable event with success=false. This made ALL error rate analytics broken:

- getMethodPerformance().failedCalls always returned 0
- getSystemHealth().errorRate always returned 0  
- detectAnomalies().highErrorRateMethods always empty

Now trackMethod() calls recordFailure() which creates an event with success=false and duration, plus recordError() for the error details. This ensures proper error tracking and analytics.

Also optimized analytics addEvents/addMetrics/addErrors to use batch push instead of individual item loops for better performance.